### PR TITLE
Add template logic that produces a static assertion failure when

### DIFF
--- a/test/size_t_and_int.cpp
+++ b/test/size_t_and_int.cpp
@@ -1,0 +1,11 @@
+#include "unit_test_framework.h"
+
+TEST(size_t_and_int) {
+  std::size_t s = 3u;
+  int i1 = -1;
+  int i2 = 3;
+  ASSERT_NOT_EQUAL(s, i1);
+  ASSERT_EQUAL(i2, s);
+}
+
+TEST_MAIN()


### PR DESCRIPTION
attempting to compare objects that cannot be compared by ==.

This hopefully produces a more understandable error than without the static assert.

Example comparing list iterators to non-iterators:

```
    List<int> empty_list;
    ASSERT_EQUAL(empty_list.begin(), nullptr);
    ASSERT_EQUAL(empty_list.begin(), 5);
```

Without the static assert on gcc:
```
In file included from List_public_test.cpp:4:
unit_test_framework.h: In instantiation of 'void assert_equal(First, Second, int) [with First = List<int>::Iterator; Second = std::nullptr_t]':
List_public_test.cpp:11:5:   required from here
unit_test_framework.h:193:15: error: 'List<T>::Iterator::Iterator(List<T>::Node*) [with T = int]' is private within this context
     if (first == second) {
         ~~~~~~^~~~~~~~~
In file included from List_public_test.cpp:3:
List.h:278:1: note: declared private here
 List<T>::Iterator::Iterator(Node *p) : node_ptr(p) {}
 ^~~~~~~
In file included from List_public_test.cpp:4:
unit_test_framework.h: In instantiation of 'void assert_equal(First, Second, int) [with First = List<int>::Iterator; Second = int]':
List_public_test.cpp:12:5:   required from here
unit_test_framework.h:193:15: error: no match for 'operator==' (operand types are 'List<int>::Iterator' and 'int')
     if (first == second) {
         ~~~~~~^~~~~~~~~
In file included from List_public_test.cpp:3:
List.h:265:6: note: candidate: 'bool List<T>::Iterator::operator==(List<T>::Iterator) const [with T = int]' <near match>
 bool List<T>::Iterator::operator==(Iterator rhs) const {
      ^~~~~~~
List.h:265:6: note:   conversion of argument 1 would be ill-formed:
In file included from List_public_test.cpp:4:
unit_test_framework.h:193:15: error: 'List<T>::Iterator::Iterator(List<T>::Node*) [with T = int]' is private within this context
     if (first == second) {
         ~~~~~~^~~~~~~~~
In file included from List_public_test.cpp:3:
List.h:278:1: note: declared private here
 List<T>::Iterator::Iterator(Node *p) : node_ptr(p) {}
 ^~~~~~~
In file included from List_public_test.cpp:4:
unit_test_framework.h:193:15: error: invalid conversion from 'int' to 'List<int>::Node*' [-fpermissive]
     if (first == second) {
         ~~~~~~^~~~~~~~~
In file included from List_public_test.cpp:3:
List.h:278:35: note:   initializing argument 1 of 'List<T>::Iterator::Iterator(List<T>::Node*) [with T = int]'
 List<T>::Iterator::Iterator(Node *p) : node_ptr(p) {}
                             ~~~~~~^
In file included from /usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/iosfwd:40,
                 from /usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/ios:38,
                 from /usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/ostream:38,
                 from /usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/iostream:39,
                 from List.h:10,
                 from List_public_test.cpp:3:
/usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/bits/postypes.h:216:5: note: candidate: 'template<class _StateT> bool std::operator==(const std::fpos<_StateT>&, const std::fpos<_StateT>&)'
     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
     ^~~~~~~~
/usr/local/Cellar/gcc/8.2.0/include/c++/8.2.0/bits/postypes.h:216:5: note:   template argument deduction/substitution failed:
In file included from List_public_test.cpp:4:
unit_test_framework.h:193:15: note:   'List<int>::Iterator' is not derived from 'const std::fpos<_StateT>'
     if (first == second) {
         ~~~~~~^~~~~~~~~
[lots more like the above]
```

Without the static assert on clang:
```
In file included from List_public_test.cpp:4:
./unit_test_framework.h:193:18: error: calling a private constructor of class
      'List<int>::Iterator'
    if (first == second) {
                 ^
List_public_test.cpp:11:5: note: in instantiation of function template
      specialization 'assert_equal<List<int>::Iterator, nullptr_t>' requested
      here
    ASSERT_EQUAL(empty_list.begin(), nullptr);
    ^
./unit_test_framework.h:179:37: note: expanded from macro 'ASSERT_EQUAL'
#define ASSERT_EQUAL(first, second) assert_equal((first), (second), __LINE__);
                                    ^
./List.h:115:5: note: declared private here
    Iterator(Node *p);
    ^
In file included from List_public_test.cpp:4:
./unit_test_framework.h:193:15: error: invalid operands to binary expression
      ('List<int>::Iterator' and 'int')
    if (first == second) {
        ~~~~~ ^  ~~~~~~
List_public_test.cpp:12:5: note: in instantiation of function template
      specialization 'assert_equal<List<int>::Iterator, int>' requested here
    ASSERT_EQUAL(empty_list.begin(), 5);
    ^
./unit_test_framework.h:179:37: note: expanded from macro 'ASSERT_EQUAL'
#define ASSERT_EQUAL(first, second) assert_equal((first), (second), __LINE__);
                                    ^
./List.h:103:10: note: candidate function not viable: no known conversion from
      'int' to 'List<int>::Iterator' for 1st argument
    bool operator==(Iterator rhs) const;
         ^
2 errors generated.
```

With the static assert on gcc:
```
In file included from List_public_test.cpp:4:
unit_test_framework.h: In instantiation of 'struct safe_equals<List<int>::Iterator, std::nullptr_t, void>':
unit_test_framework.h:234:43:   required from 'void assert_equal(First, Second, int) [with First = List<int>::Iterator; Second = std::nullptr_t]'
List_public_test.cpp:11:5:   required from here
unit_test_framework.h:210:19: error: static assertion failed: types cannot be compared with ==
     static_assert(is_equality_comparable<First, Second>::value,
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unit_test_framework.h: In instantiation of 'struct safe_equals<List<int>::Iterator, int, void>':
unit_test_framework.h:234:43:   required from 'void assert_equal(First, Second, int) [with First = List<int>::Iterator; Second = int]'
List_public_test.cpp:12:5:   required from here
unit_test_framework.h:210:19: error: static assertion failed: types cannot be compared with ==
```

With the static assert on clang:
```
In file included from List_public_test.cpp:4:
./unit_test_framework.h:210:5: error: static_assert failed due to requirement
      'is_equality_comparable<Iterator, nullptr_t>::value' "types cannot be
      compared with =="
    static_assert(is_equality_comparable<First, Second>::value,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./unit_test_framework.h:234:9: note: in instantiation of template class
      'safe_equals<List<int>::Iterator, nullptr_t, void>' requested here
    if (safe_equals<First, Second>::equals(first, second)) {
        ^
List_public_test.cpp:11:5: note: in instantiation of function template
      specialization 'assert_equal<List<int>::Iterator, nullptr_t>' requested
      here
    ASSERT_EQUAL(empty_list.begin(), nullptr);
    ^
./unit_test_framework.h:180:37: note: expanded from macro 'ASSERT_EQUAL'
#define ASSERT_EQUAL(first, second) assert_equal((first), (second), __LINE__);
                                    ^
./unit_test_framework.h:210:5: error: static_assert failed due to requirement
      'is_equality_comparable<Iterator, int>::value' "types cannot be compared
      with =="
    static_assert(is_equality_comparable<First, Second>::value,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./unit_test_framework.h:234:9: note: in instantiation of template class
      'safe_equals<List<int>::Iterator, int, void>' requested here
    if (safe_equals<First, Second>::equals(first, second)) {
        ^
List_public_test.cpp:12:5: note: in instantiation of function template
      specialization 'assert_equal<List<int>::Iterator, int>' requested here
    ASSERT_EQUAL(empty_list.begin(), 5);
    ^
./unit_test_framework.h:180:37: note: expanded from macro 'ASSERT_EQUAL'
#define ASSERT_EQUAL(first, second) assert_equal((first), (second), __LINE__);
                                    ^
2 errors generated.
```
