### PR TITLE
Add overloads to print out the elements of pairs and sequences.

### DIFF
--- a/test/pairs_and_sequences.correct.txt
+++ b/test/pairs_and_sequences.correct.txt
@@ -1,5 +1,9 @@
 Running test: map_print
 FAIL
+Running test: nested_pair_print
+FAIL
+Running test: nested_vector_print
+FAIL
 Running test: pair_print
 FAIL
 Running test: vector_print
@@ -10,6 +14,14 @@ FAIL
 In test , line 28: 
 { (hello,3), (world,-1) } != { (hello,4), (world,-1) }
 
+** Test case "nested_pair_print": FAIL
+In test , line 44: 
+{ ((foo,bar),-1), ((hello,world),3) } != { ((bar,foo),-1), ((hello,world),3) }
+
+** Test case "nested_vector_print": FAIL
+In test , line 34: 
+{ { 1.1, 2.3 }, { -4.6 } } != { { 1.1, 2.3 }, { -4.6, 8.7 } }
+
 ** Test case "pair_print": FAIL
 In test , line 18: 
 (hello,3) != (hello,4)
@@ -19,5 +31,5 @@ In test , line 12:
 {} != { 3, 4 }
 
 *** Summary ***
-Out of 3 tests run:
-3 failure(s), 0 error(s)
+Out of 5 tests run:
+5 failure(s), 0 error(s)

--- a/test/pairs_and_sequences.correct.txt
+++ b/test/pairs_and_sequences.correct.txt
@@ -1,0 +1,23 @@
+Running test: map_print
+FAIL
+Running test: pair_print
+FAIL
+Running test: vector_print
+FAIL
+
+*** Results ***
+** Test case "map_print": FAIL
+In test , line 28: 
+{ (hello,3), (world,-1) } != { (hello,4), (world,-1) }
+
+** Test case "pair_print": FAIL
+In test , line 18: 
+(hello,3) != (hello,4)
+
+** Test case "vector_print": FAIL
+In test , line 12: 
+{} != { 3, 4 }
+
+*** Summary ***
+Out of 3 tests run:
+3 failure(s), 0 error(s)

--- a/test/pairs_and_sequences.cpp
+++ b/test/pairs_and_sequences.cpp
@@ -1,0 +1,31 @@
+#include <map>
+#include <string>
+#include <vector>
+#include <utility>
+#include "unit_test_framework.h"
+
+using namespace std;
+
+TEST(vector_print) {
+    vector<int> v1;
+    vector<int> v2 = { 3, 4 };
+    ASSERT_EQUAL(v1, v2);
+}
+
+TEST(pair_print) {
+    pair<string, int> p1 = { "hello", 3 };
+    pair<string, int> p2 = { "hello", 4 };
+    ASSERT_EQUAL(p1, p2);
+}
+
+TEST(map_print) {
+    map<string, int> m1;
+    map<string, int> m2;
+    m1["hello"] = 3;
+    m2["hello"] = 4;
+    m1["world"] = -1;
+    m2["world"] = -1;
+    ASSERT_EQUAL(m1, m2);
+}
+
+TEST_MAIN()

--- a/test/pairs_and_sequences.cpp
+++ b/test/pairs_and_sequences.cpp
@@ -28,4 +28,20 @@ TEST(map_print) {
     ASSERT_EQUAL(m1, m2);
 }
 
+TEST(nested_vector_print) {
+  vector<vector<double>> vs1 = { { 1.1, 2.3 }, { -4.6 } };
+  vector<vector<double>> vs2 = { { 1.1, 2.3 }, { -4.6, 8.7 } };
+  ASSERT_EQUAL(vs1, vs2);
+}
+
+TEST(nested_pair_print) {
+  map<pair<string, string>, int> m1;
+  map<pair<string, string>, int> m2;
+  m1[{ "hello", "world" }] = 3;
+  m1[{ "foo", "bar" }] = -1;
+  m2[{ "hello", "world" }] = 3;
+  m2[{ "bar", "foo" }] = -1;
+  ASSERT_EQUAL(m1, m2);
+}
+
 TEST_MAIN()


### PR DESCRIPTION
Instead of just printing out their types.

Old output for `test/pairs_and_sequences.cpp` (gcc/clang):

```
Running test: map_print
FAIL
Running test: pair_print
FAIL
Running test: vector_print
FAIL

*** Results ***
** Test case "map_print": FAIL
In test , line 28: 
<std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, int> > > object> != <std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, int> > > object>

** Test case "pair_print": FAIL
In test , line 18: 
<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int> object> != <std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, int> object>

** Test case "vector_print": FAIL
In test , line 12: 
<std::__1::vector<int, std::__1::allocator<int> > object> != <std::__1::vector<int, std::__1::allocator<int> > object>

*** Summary ***
Out of 3 tests run:
3 failure(s), 0 error(s)
```

New output:

```
Running test: map_print
FAIL
Running test: pair_print
FAIL
Running test: vector_print
FAIL

*** Results ***
** Test case "map_print": FAIL
In test , line 28: 
{ (hello,3), (world,-1) } != { (hello,4), (world,-1) }

** Test case "pair_print": FAIL
In test , line 18: 
(hello,3) != (hello,4)

** Test case "vector_print": FAIL
In test , line 12: 
{} != { 3, 4 }

*** Summary ***
Out of 3 tests run:
3 failure(s), 0 error(s)
```