### PR TITLE
Allow comparisons between string and char arrays.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ test_dir = test
 test_exes = $(test_dir)/test_special_asserts.exe \
 			$(test_dir)/end_to_end_test.exe \
 			$(test_dir)/test_early_exit.exe \
-			$(test_dir)/sequence_equal.exe
+			$(test_dir)/sequence_equal.exe \
+			$(test_dir)/string_equal.exe
 
 end_to_end_corrects = $(wildcard $(test_dir)/*.correct.txt)
 end_to_end_targets = $(end_to_end_corrects:.correct.txt=.end_to_end)
@@ -32,6 +33,7 @@ test: $(test_exes) $(test_dir)/end_to_end_test.exe
 	$(call run_and_diff,$(test_dir)/end_to_end_test.exe should_pass,run_subset_of_tests_test)
 	$(call run_and_diff,$(test_dir)/end_to_end_test.exe should_pass -q should_fail,quiet_run_subset_of_tests)
 	$(call run_and_diff,$(test_dir)/sequence_equal.exe,sequence_equal)
+	$(call run_and_diff,$(test_dir)/string_equal.exe,string_equal)
 
 %.o: %.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< -c -o $@

--- a/test/string_equal.correct.txt
+++ b/test/string_equal.correct.txt
@@ -1,0 +1,8 @@
+Running test: string_equal
+PASS
+
+*** Results ***
+** Test case "string_equal": PASS
+*** Summary ***
+Out of 1 tests run:
+0 failure(s), 0 error(s)

--- a/test/string_equal.cpp
+++ b/test/string_equal.cpp
@@ -1,0 +1,19 @@
+#include <string>
+#include "unit_test_framework.h"
+
+TEST(string_equal) {
+  std::string s1 = "hello";
+  ASSERT_EQUAL(s1, "hello");
+  ASSERT_EQUAL("hello", s1);
+  char cs[] = "hello";
+  ASSERT_EQUAL(s1, cs);
+  ASSERT_EQUAL(cs, s1);
+
+  std::string s2 = "world";
+  ASSERT_NOT_EQUAL(s2, "hello");
+  ASSERT_NOT_EQUAL("hello", s2);
+  ASSERT_NOT_EQUAL(s2, cs);
+  ASSERT_NOT_EQUAL(cs, s2);
+}
+
+TEST_MAIN()

--- a/unit_test_framework.h
+++ b/unit_test_framework.h
@@ -270,8 +270,8 @@ template <typename First, typename Second>
 using enable_if_equality_comparable = typename std::enable_if<
     std::is_same<bool, decltype(std::declval<First>() ==
                                 std::declval<Second>())>::value &&
-        !std::is_array<typename std::remove_reference<First>::type>::value &&
-        !std::is_array<typename std::remove_reference<Second>::type>::value,
+        (!std::is_array<typename std::remove_reference<First>::type>::value or
+         !std::is_array<typename std::remove_reference<Second>::type>::value),
     void>::type;
 
 template <typename First, typename Second>


### PR DESCRIPTION
Old logic prevented either argument to `ASSERT_EQUAL()` from being an array. New logic only prevents the case when both arguments are arrays.