### PR TITLE
Update tutorial to no longer depend on lab 2

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -253,6 +253,20 @@ Compile and run the tests with the following commands:
 ```console
 $ g++ -Wall -Werror -pedantic -O1 -std=c++11 arrays.cpp arrays_tests.cpp -o arrays_tests.exe
 $ ./arrays_tests.exe
+Running test: test_flip_1
+PASS
+Running test: test_slide_right_1
+FAIL
+
+*** Results ***
+** Test case "test_flip_1": PASS
+** Test case "test_slide_right_1": FAIL
+In ASSERT_TRUE(compare_arrays(testing, 5, correct, 5)), line 24:
+Expected true, but was false
+
+*** Summary ***
+Out of 2 tests run:
+1 failure(s), 0 error(s)
 ```
 
 A failed test indicates there's a bug in our `arrays.cpp` code. The tests above caught

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,24 +9,33 @@ In this tutorial, you will learn how to write test cases using a lightweight fra
 - [Setting Up](#setting-up)
 - [Special Test Assertions](#special-test-assertions)
 - [Example: Tests for an `add()` function](#example-tests-for-an-add-function)
-- [Write Unit Tests for `slideright()` and `flip()` (Lab 2)](#write-unit-tests-for-slideright-and-flip-lab-2)
-- [Write a `compare_arrays()` Function (Lab 2)](#write-a-compare_arrays-function-lab-2)
-- [Extra: Convert your Project 1 Tests to use the Framework](#extra-convert-your-project-1-tests-to-use-the-framework)
+- [Writing Unit Tests for `slideright()` and `flip() array functions`](#writing-unit-tests-for-slideright-and-flip-array-functions)
+- [Write a `compare_arrays()` Function](#write-a-compare_arrays-function)
+- [Writing Helper Functions for Tests](#writing-helper-functions-for-tests)
 
 <!-- tocstop -->
 
 # Setting Up
 
-First, you will need the file `unit_test_framework.h`. This file is available with the starter files for Lab 2, but you can also download it with the following command.
+First, you will need the file `unit_test_framework.h`. This file is included with the starter code for EECS 280 projects where you are expected to use it. You can also download it directly (e.g. for this tutorial) with the following command.
 
 ```console
 $ wget https://raw.githubusercontent.com/eecs280staff/unit_test_framework/master/unit_test_framework.h
 ```
 
-Second, create a file called `lab02_tests.cpp`. Add the following code to `lab02_tests.cpp`:
+For this tutorial, you'll need two files, `arrays.h` and `arrays.cpp`.
+
+```console
+$ wget https://raw.githubusercontent.com/eecs280staff/unit_test_framework/arrays.h
+$ wget https://raw.githubusercontent.com/eecs280staff/unit_test_framework/arrays.cpp
+```
+
+These functions contain implementations of two functions (`slideRight()` and `flip()`) that work with arrays. The implementations each contain a bug! You'll catch the bugs by writing tests.
+
+Your tests should go in a new file, called `arrays_tests.cpp`. Add the following code to `arrays_tests.cpp`:
 
 ```c++
-#include "lab02.h"
+#include "arrays.h"
 #include "unit_test_framework.h"
 
 // We define a test case with the TEST(<test_name>) macro.
@@ -42,6 +51,8 @@ TEST(numbers_are_equal) {
 TEST_MAIN() // No semicolon!
 ```
 
+These are just example tests...we'll get to "real" tests for our array functions soon.
+
 You're probably wondering why some of the syntax in this code looks unusual. That's because this testing framework uses preprocessor macros to achieve functionality that wouldn't be possible with the plain C++ you're used to seeing. Preprocessor macros are beyond the scope of this course and in general should be used sparingly, so here's all you need to know:
 
   - The `TEST(<test_name>)` essentially gets replaced (by the preprocessor) with a test function called `<test_name>`, where `<test_name>` is any valid C++ function name and `<test_name>` will be the name of the new test function. You do **NOT** need to put quotes around `<test_name>`, and if you do you'll get a compiler error.
@@ -53,8 +64,8 @@ You're probably wondering why some of the syntax in this code looks unusual. Tha
 Compile and run this test case with the following two commands:
 
 ```console
-$ g++ -Wall -Werror -pedantic -g -std=c++11 lab02.cpp lab02_tests.cpp -o lab02_tests.exe
-$ ./lab02_tests.exe
+$ g++ -Wall -Werror -pedantic -g -std=c++11 arrays.cpp arrays_tests.cpp -o arrays_tests.exe
+$ ./arrays_tests.exe
 Running test: numbers_are_equal
 PASS
 Running test: true_is_true
@@ -71,7 +82,7 @@ Out of 2 tests run:
 Another nice feature of the framework is that we can tell it to run only a subset of our test cases. If we wanted to only run the test `numbers_are_equal`, we could do it with this command:
 
 ```console
-$ ./lab02_tests.exe numbers_are_equal
+$ ./arrays_tests.exe numbers_are_equal
 Running test: numbers_are_equal
 PASS
 
@@ -114,7 +125,7 @@ We could write a test case for `add()` using `assert()` as follows:
 
 ```c++
 void add_test_basic();
-bool doubles_close(double first, double second, double range);
+bool doubles_almost_equal(double first, double second, double range);
 
 int main() {
   add_test_basic();
@@ -130,16 +141,16 @@ void add_test_basic() {
   cout << "expected_sum: " << expected_sum << endl;
   cout << "actual_sum: " << actual_sum << endl;
 
-  assert(doubles_close(expected_sum, actual_sum, .001));
+  assert(doubles_almost_equal(expected_sum, actual_sum, .001));
 }
 
-bool doubles_close(double first, double second, double range) {
+bool doubles_almost_equal(double first, double second, double range) {
   double diff = abs(first - second);
   return diff < range;
 }
 ```
 
-The `doubles_close()` function above determines if two `double` values
+The `doubles_almost_equal()` function above determines if two `double` values
 are equal to each other within a given range of precision. Since
 `double` values are not exact, it isn't safe to compare non-integral
 `double` values with the == operator.
@@ -158,11 +169,11 @@ TEST(add_basic) {
   cout << "expected_sum: " << expected_sum << endl;
   cout << "actual_sum: " << actual_sum << endl;
 
-  ASSERT_TRUE(doubles_close(expected_sum, actual_sum, .001));
+  ASSERT_TRUE(doubles_almost_equal(expected_sum, actual_sum, .001));
 }
 ```
 
-Next, instead of using our own `doubles_close()` function, let's use `ASSERT_ALMOST_EQUAL()` from the framework:
+Next, instead of using our own `doubles_almost_equal()` function, let's use `ASSERT_ALMOST_EQUAL()` from the framework. You should always use the "almost" version when comparing results that might be slightly different due to limited numeric precision.
 
 ```c++
 TEST(add_basic) {
@@ -179,8 +190,8 @@ TEST(add_basic) {
 Finally, let's add `TEST_MAIN()` and any `#include`s that we need:
 
 ```c++
-#include “eecs280math.h”
-#include “unit_test_framework.h”
+#include "eecs280math.h"
+#include "unit_test_framework.h"
 
 TEST(add_basic) {
   double a = 0.1;
@@ -194,43 +205,92 @@ TEST(add_basic) {
 TEST_MAIN()
 ```
 
-# Write Unit Tests for `slideright()` and `flip()` (Lab 2)
+# Writing Unit Tests for `slideright()` and `flip()` array functions
 
-Add test cases for `slideRight()` and `flip()` to `lab02_tests.cpp`.
+Now, let's add some real test cases for `slideRight()` and `flip()` to `arrays_tests.cpp`.
+
+For example, here's one test for each function (you can replace your existing code in `arrays_tests.cpp` with the code below):
+
+```c++
+#include "arrays.h"
+#include "unit_test_framework.h"
+
+// A helper function for comparing arrays. Returns true if the
+// arrays are the same size and contain the same values.
+bool compare_arrays(int arr1[], int size1, int arr2[], int size2) {
+  if (size1 != size2) {
+    return false;
+  }
+
+  for (int i = 0; i < size1; ++i) {
+    if (arr1[i] != arr2[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+TEST(test_slide_right_1) {
+  int testing[] = { 4, 0, 1, 3, 3 };
+  int correct[] = { 3, 4, 0, 1, 3 };
+  slideRight(testing, 5);
+  ASSERT_TRUE(compare_arrays(testing, 5, correct, 5));
+}
+
+TEST(test_flip_1) {
+  int testing[] = { 4, 0, 1, 3, 3 };
+  int correct[] = { 3, 3, 1, 0, 4 };
+  flip(testing, 5);
+  ASSERT_TRUE(compare_arrays(testing, 5, correct, 5));
+}
+
+TEST_MAIN() // No semicolon!
+```
 
 Compile and run the tests with the following commands:
 
 ```console
-$ g++ -Wall -Werror -pedantic -O1 -std=c++11 lab02.cpp lab02_tests.cpp -o lab02_tests.exe
-$ ./lab02_tests.exe
+$ g++ -Wall -Werror -pedantic -O1 -std=c++11 arrays.cpp arrays_tests.cpp -o arrays_tests.exe
+$ ./arrays_tests.exe
 ```
 
-Of course, if you run your tests against your own (correct) implementations
-in lab02.cpp, the tests should all pass. (We call tests that pass when run
-against a correct implementation _valid_.) You can temporarily change one of
-your functions to contain a bug and observe that some tests fail.
+A failed test indicates there's a bug in our `arrays.cpp` code. The tests above caught
+the bug in `slideRight` but not the one in `flip` (recall we mentioned there is a bug in both).
+You'll need to write more tests to create a thorough testing suite!
+Ideally, you should have enough tests that any reasonable bug will cause at least
+one test to fail.
 
-Once you feel your tests are thorough, submit `lab02_tests.cpp` to the lab 2
+On the other hand, when run against a correct implementation, all of your tests should pass. (Otherwise, it would be giving a false positive for detecting a bug.) If a test passes on a correct implementation,
+we call it _valid_.
+
+Once you feel your tests are thorough, submit `arrays_tests.cpp` to the unit test framework tutorial
 autograder. It will check your tests against a set of buggy implementations
-of `slideRight` and `flip`. To earn points for the lab, your tests must detect
+of `slideRight` and `flip`, similar to the buggy versions functions provided with
+this tutorial. To earn points, your tests must detect
 (i.e. fail when run against) each of the bugs. Note that the autograder will
 discard any tests that are not valid when checked against a correct solution.
 
-# Write a `compare_arrays()` Function (Lab 2)
+**Note**: Because these functions work with arrays, it's possible that a buggy version might go outside the bounds of the array when given one of your tests, causing a segfault or other crash. For example:
 
-You may have noticed some duplicated code in your test cases, particularly when checking the expected and actual contents of arrays. Write a function called `compare_arrays()` that takes in two arrays and their lengths and checks that the contents of those arrays are equal using the framework's special assertions. Then, refactor your test cases to use `compare_arrays()` instead of duplicating code.
+```console
+$ ./arrays_tests.exe
+Running test: test_flip_1
+PASS
+Running test: test_flip_2
+Segmentation fault
+```
 
-**Note**: Since `compare_arrays()` is a test helper, it should be within `lab02_tests.cpp`!
+This still "counts" as catching the bug, because the program exits with a non-zero exit status (as is the case failed assertion) and we are alerted to the presence of a bug.
+
+# Writing Helper Functions for Tests
+
+You may have noticed some duplicated code in your test cases, particularly when checking the expected and actual contents of arrays. It would be a good idea to write a function called `compare_arrays()` that takes in two arrays and their lengths and checks that the contents of those arrays are equal using the framework's special assertions. Then, you can refactor your test cases to use `compare_arrays()` instead of duplicating code.
+
+**Note**: Since `compare_arrays()` is a test helper, it should be within `arrays_tests.cpp`!
 
 **Note**: `compare_arrays()` is different from
 `ASSERT_SEQUENCE_EQUAL()`. The latter works on arrays, but not on
 pointers that decayed from arrays. You will not be able to use
 `ASSERT_SEQUENCE_EQUAL()` in `compare_arrays()`.
 
-# Extra: Convert your Project 1 Tests to use the Framework
-
-If you want extra practice with the framework before using it for your test cases in Project 2, update your unit tests for `stats.cpp` so that they use this framework.
-
-**Note**: Do **NOT** submit these updated test cases to the Project 1 autograder, as the framework will not be available there.
-
-*Hint*: You can take advantage of `ASSERT_ALMOST_EQUAL()` to compare doubles in your test cases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -265,7 +265,7 @@ On the other hand, when run against a correct implementation, all of your tests 
 we call it _valid_.
 
 Once you feel your tests are thorough, submit `arrays_tests.cpp` to the unit test framework tutorial
-autograder. It will check your tests against a set of buggy implementations
+[autograder](https://autograder.io/). It will check your tests against a set of buggy implementations
 of `slideRight` and `flip`, similar to the buggy versions functions provided with
 this tutorial. To earn points, your tests must detect
 (i.e. fail when run against) each of the bugs. Note that the autograder will
@@ -293,4 +293,3 @@ You may have noticed some duplicated code in your test cases, particularly when 
 `ASSERT_SEQUENCE_EQUAL()`. The latter works on arrays, but not on
 pointers that decayed from arrays. You will not be able to use
 `ASSERT_SEQUENCE_EQUAL()` in `compare_arrays()`.
-

--- a/docs/arrays.cpp
+++ b/docs/arrays.cpp
@@ -1,7 +1,5 @@
 #include "arrays.h"
 
-using namespace std;
-
 // REQUIRES: there are at least n elements in arr;
 //           n >= 1
 // MODIFIES: the elements in arr

--- a/docs/arrays.cpp
+++ b/docs/arrays.cpp
@@ -1,0 +1,36 @@
+#include "arrays.h"
+
+using namespace std;
+
+// REQUIRES: there are at least n elements in arr;
+//           n >= 1
+// MODIFIES: the elements in arr
+// EFFECTS:  All elements are "shifted" right by one unit, with the
+//           last element wrapping around to the beginning.
+// EXAMPLE:  If arr contains [0,1,3,3,4], it would be modified to
+//           contain [4,0,1,3,3]
+void slideRight(int arr[], int n) {
+  // NOTE - This implementation contains a bug!
+  for(int i = 1; i < n; ++i) {
+    arr[i] = arr[i-1];
+  }
+}
+
+// REQUIRES: there are at least n elements in arr;
+//           n >= 0
+// MODIFIES: the elements in arr
+// EFFECTS:  Reverses the order of the elements in arr.
+// EXAMPLE:  If arr contains, [1,2,3,4,5], it would be modified to
+//           contain [5,4,3,2,1]
+void flip(int arr[], int n) {
+  // NOTE - This implementation contains a bug!
+  int *left = arr;
+  int *right = arr + n - 1;
+  while(left != right) {
+    int temp = *left;
+    *left = *right;
+    *right = temp;
+    ++left;
+    --right;
+  }
+}

--- a/docs/arrays.h
+++ b/docs/arrays.h
@@ -1,0 +1,16 @@
+// REQUIRES: there are at least n elements in arr;
+//           n >= 1
+// MODIFIES: the elements in arr
+// EFFECTS:  All elements are "shifted" right by one unit, with the
+//           last element wrapping around to the beginning.
+// EXAMPLE:  If arr contains [0,1,3,3,4], it would be modified to
+//           contain [4,0,1,3,3]
+void slideRight(int arr[], int n);
+
+// REQUIRES: there are at least n elements in arr;
+//           n >= 0
+// MODIFIES: the elements in arr
+// EFFECTS:  Reverses the order of the elements in arr.
+// EXAMPLE:  If arr contains, [1,2,3,4,5], it would be modified to
+//           contain [5,4,3,2,1]
+void flip(int arr[], int n);


### PR DESCRIPTION
This PR updates the tutorial for the unit testing framework that we have students complete in 280 so that it no longer depends on lab 2 files. The relevant files/functions are now included directly with the tutorial and it does not specifically mention lab 2.

Completing the tutorial can still be a part of lab 2. But it now can also be reasonably completed on its own.

I set up an autograder for just the mutation testing part of lab 2 at https://autograder.io/web/project/964. (It is not public to students yet.)

In particular, this tutorial does **not** change the unit testing framework itself, just the tutorial.