### PR TITLE
Polish test output using text color and other ANSI escape codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ $(test_dir)/%.exe: $(test_dir)/%.o
 # 1. executable plus args
 # 2. base for .correct.txt and .out.txt files
 define run_and_diff
-	-./$1 > $(test_dir)/$2.out.txt 2>&1;
+	-NO_COLOR=1 ./$1 -s > $(test_dir)/$2.out.txt 2>&1;
 	diff -q $(test_dir)/$2.correct.txt $(test_dir)/$2.out.txt || sdiff $(test_dir)/$2.correct.txt $(test_dir)/$2.out.txt;
 endef
 

--- a/unit_test_framework.h
+++ b/unit_test_framework.h
@@ -108,6 +108,10 @@ public:
         quiet_mode = true;
     }
 
+    void enable_show_completed() {
+        show_completed = true;
+    }
+
     std::ostream& print_test_names(std::ostream& os) {
         for (const auto& test_pair : tests_) {
             os << test_pair.first << '\n';
@@ -139,6 +143,7 @@ private:
     static TestSuite* instance;
     std::map<std::string, TestCase> tests_;
 
+    bool show_completed = false;
     bool quiet_mode = false;
     static bool incomplete;
 };
@@ -555,7 +560,8 @@ int TestSuite::run_tests(int argc, char** argv) {
         tests_.at(test_name).run(quiet_mode);
     }
 
-    if (!quiet_mode) clear_output(tests_.size() * 2);
+    if (!quiet_mode && !show_completed) clear_output(tests_.size() * 2);
+    else std::cout << std::endl;
     std::cout << "*** Results ***" << std::endl;
     for (auto test_name : test_names_to_run) {
         tests_.at(test_name).print(quiet_mode);
@@ -607,6 +613,10 @@ std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
                  argv[i] == std::string("-q")) {
             TestSuite::get().enable_quiet_mode();
         }
+        else if (argv[i] == std::string("--show_completed") or
+                 argv[i] == std::string("-s")) {
+            TestSuite::get().enable_show_completed();
+        }
         else if (argv[i] == std::string("--help") or
                  argv[i] == std::string("-h")) {
             std::cout << "usage: " << argv[0]
@@ -617,6 +627,8 @@ std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
                 << " -n, --show_test_names\t print the names of all "
                    "discovered test cases and exit\n"
                 << " -q, --quiet\t\t print a reduced summary of test results\n"
+                << " -s, --show_completed\t disable the clearing of running "
+                   "tests when the results are printed\n" 
                 << " TEST_NAME ...\t\t run only the test cases whose names "
                    "are "
                    "listed here. Note: If no test names are specified, all "


### PR DESCRIPTION
Hello,

I am a student in EECS 280, and this is a modification of the framework which I created for my own use, and then polished for this PR. It adds two main features:

* Text color for PASS, FAIL, and ERROR messages to make them easier to distinguish at a glance (as well as compliance with the [informal `NO_COLOR` standard](http://no-color.org/))
* Clearing the `Running test:` text after all tests have run so that at the end, the results list is the only visible output

One issue that still exists is that if the tests print `n` newlines to `std::cout`, it will clear `n` too few lines before outputting the summary. I'm not sure if there is a good solution to this, aside from just clearing the entire screen before outputting the summary (or perhaps hijacking `std::cout` to count newlines or something else beyond my C++ skill level), but I don't think there are many situations in which a test case would have to print text, and even when it does, the output is still workable.

So far, I have verified that this works both on Linux and WSL, although I have not yet been able to test it on MacOS. I'd love to hear any thoughts you might have!

-Nova