### PR TITLE
Remove g++ 4.8 from CI

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -23,26 +23,8 @@ jobs:
       #
       # Virtual Environments: OSes and preinstalled software:
       # https://github.com/actions/virtual-environments
-      #
-      # Many are commented out to avoid going over budget
       matrix:
         include:
-          - os: ubuntu-18.04
-            compiler: g++-4.8
-          # - os: ubuntu-16.04
-          #   compiler: g++-5
-          # - os: ubuntu-18.04
-          #   compiler: g++-7
-          # - os: ubuntu-18.04
-          #   compiler: g++-8
-          # - os: ubuntu-18.04
-          #   compiler: g++-9
-          # - os: ubuntu-18.04
-          #   compiler: g++-10
-          # - os: ubuntu-18.04
-          #   compiler: clang++-8
-          # - os: ubuntu-18.04
-          #   compiler: clang++-9
           - os: ubuntu-latest
             compiler: g++
           - os: macOS-latest
@@ -54,10 +36,6 @@ jobs:
       # Docs: https://github.com/actions/checkout
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Install old compiler
-        if: matrix.compiler == 'g++-4.8'
-        run: sudo apt-get install g++-4.8
 
       # Run tests
       - name: Run tests


### PR DESCRIPTION
The old version of g++ is causing trouble with CI (this happened in our other repos as well). Applying the same solution here, which is to remove it from CI.