### PR TITLE
Disable regular expressions unless the macro UNIT_TEST_ENABLE_REGEX is defined to 1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: $(test_exes) $(test_dir)/end_to_end_test.exe
 	$(CXX) $(CXXFLAGS) -I. \
 					   $(test_dir)/test_name_conflict_file_with_non_static_func.cpp \
 					   $(test_dir)/test_name_conflict_file_with_tests.cpp \
-					   -o no_conflict.exe
+					   -o $(test_dir)/no_conflict.exe
 
 	! $(CXX) $(CXXFLAGS_NO_WARNINGS) -I. $(test_dir)/array_compare_error.cpp
 	! $(CXX) $(CXXFLAGS_NO_WARNINGS) -I. $(test_dir)/missing_overload_error.cpp
@@ -39,13 +39,18 @@ test: $(test_exes) $(test_dir)/end_to_end_test.exe
 
 	$(call run_and_diff,$(test_dir)/end_to_end_test.exe should_pass,run_subset_of_tests_test)
 	$(call run_and_diff,$(test_dir)/end_to_end_test.exe should_pass -q should_fail,quiet_run_subset_of_tests)
-	$(call run_and_diff,$(test_dir)/end_to_end_test.exe -e ".*almost.*",regexp_test1)
-	$(call run_and_diff,$(test_dir)/end_to_end_test.exe --regexp ".*almost.*" "should.*",regexp_test2)
 	$(call run_and_diff,$(test_dir)/pairs_and_sequences.exe,pairs_and_sequences)
 	$(call run_and_diff,$(test_dir)/sequence_equal.exe,sequence_equal)
 	$(call run_and_diff,$(test_dir)/string_equal.exe,string_equal)
 	./$(test_dir)/size_t_and_int.exe
 	$(call run_and_diff,$(test_dir)/char_array.exe,char_array)
+
+	$(CXX) $(CXXFLAGS) -DUNIT_TEST_ENABLE_REGEXP -I. \
+					   $(test_dir)/end_to_end_test.cpp \
+					   -o $(test_dir)/end_to_end_test_regexp.exe
+	$(call run_and_diff,$(test_dir)/end_to_end_test_regexp.exe -e ".*almost.*",regexp_test1)
+	$(call run_and_diff,$(test_dir)/end_to_end_test_regexp.exe --regexp ".*almost.*" "should.*",regexp_test2)
+
 	@echo TESTS PASSED
 
 %.o: %.cpp

--- a/README.md
+++ b/README.md
@@ -104,10 +104,9 @@ You can use any amount of these special asserts in your test cases. You can also
 ## Command line options
 ```console
 $ ./my_tests.exe -h
-usage: ./my_tests.exe [-h] [-e] [-n] [-q] [[TEST_NAME] ...]
+usage: ./my_tests.exe [-h] [-n] [-q] [[TEST_NAME] ...]
 optional arguments:
  -h, --help		 show this help message and exit
- -e, --regexp		 treat TEST_NAME as a regular expression
  -n, --show_test_names	 print the names of all discovered test cases and exit
  -q, --quiet		 print a reduced summary of test results
  TEST_NAME ...		 run only the test cases whose names are listed here. Note: If no test names are specified, all discovered tests are run by default.
@@ -133,6 +132,39 @@ PASS
 
 *** Results ***
 ** Test case 'bool_is_true': PASS
+*** Summary ***
+Out of 1 tests run:
+0 failure(s), 0 error(s)
+```
+
+### Enabling regular expressions
+By default, the unit test framework looks for exact matches to the
+test names supplied at the command line. Matching via regular
+expressions can be enabled by defining the `UNIT_TEST_ENABLE_REGEXP`
+macro to 1 prior to #including `unit_test_framework.hpp` (or when
+compiling the test executable, such as with
+`-DUNIT_TEST_ENABLE_REGEXP` for GCC or Clang), and then passing the
+`-e` flag to the test executable.
+
+```console
+$ g++ -std=c++11 -DUNIT_TEST_ENABLE_REGEXP -o my_tests.exe my_tests.cpp
+$ ./my_tests.exe -h
+usage: ./my_tests.exe [-h] [-e] [-n] [-q] [[TEST_NAME] ...]
+optional arguments:
+ -h, --help		 show this help message and exit
+ -e, --regexp		 treat TEST_NAME as a regular expression
+ -n, --show_test_names	 print the names of all discovered test cases and exit
+ -q, --quiet		 print a reduced summary of test results
+ TEST_NAME ...		 run only the test cases whose names are listed here. Note: If no test names are specified, all discovered tests are run by default.
+```
+
+```console
+$ ./my_tests.exe -e "bool.*"
+Running test: bool_is_true
+PASS
+
+*** Results ***
+** Test case "bool_is_true": PASS
 *** Summary ***
 Out of 1 tests run:
 0 failure(s), 0 error(s)

--- a/unit_test_framework.hpp
+++ b/unit_test_framework.hpp
@@ -16,7 +16,9 @@
 #include <algorithm>
 #include <exception>
 #include <stdexcept>
-#include <regex>
+#if UNIT_TEST_ENABLE_REGEXP
+#  include <regex>
+#endif
 
 // For compatibility with Visual Studio
 #include <ciso646>
@@ -543,7 +545,9 @@ int TestSuite::run_tests(int argc, char** argv) {
 std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
                                                           char** argv) {
     std::vector<std::string> test_names_to_run;
+#if UNIT_TEST_ENABLE_REGEXP
     bool regexp_matching = false;
+#endif
     for (auto i = 1; i < argc; ++i) {
         if (argv[i] == std::string("--show_test_names") or
             argv[i] == std::string("-n")) {
@@ -556,18 +560,26 @@ std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
                  argv[i] == std::string("-q")) {
             TestSuite::get().enable_quiet_mode();
         }
+#if UNIT_TEST_ENABLE_REGEXP
         else if (argv[i] == std::string("--regexp") or
                  argv[i] == std::string("-e")) {
           regexp_matching = true;
         }
+#endif
         else if (argv[i] == std::string("--help") or
                  argv[i] == std::string("-h")) {
             std::cout << "usage: " << argv[0]
+#if UNIT_TEST_ENABLE_REGEXP
                       << " [-h] [-e] [-n] [-q] [[TEST_NAME] ...]\n";
+#else
+                      << " [-h] [-n] [-q] [[TEST_NAME] ...]\n";
+#endif
             std::cout
                 << "optional arguments:\n"
                 << " -h, --help\t\t show this help message and exit\n"
+#if UNIT_TEST_ENABLE_REGEXP
                 << " -e, --regexp\t\t treat TEST_NAME as a regular expression\n"
+#endif
                 << " -n, --show_test_names\t print the names of all "
                    "discovered test cases and exit\n"
                 << " -q, --quiet\t\t print a reduced summary of test results\n"
@@ -590,6 +602,7 @@ std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
             std::back_inserter(test_names_to_run),
             [](const std::pair<std::string, TestCase>& p) { return p.first; });
     }
+#if UNIT_TEST_ENABLE_REGEXP
     else if (regexp_matching) {
         std::ostringstream pattern;
         for (auto iter = test_names_to_run.begin();
@@ -607,6 +620,7 @@ std::vector<std::string> TestSuite::get_test_names_to_run(int argc,
             }
         }
     }
+#endif
     return test_names_to_run;
 }
 


### PR DESCRIPTION
PR #53 added the ability to match names at the command line via regular expressions to address issue #44. However, the C++ `<regex>` header is quite large, and we have found that compiling on the autograder with sanitizers enabled takes an unacceptably long time with `<regex>` included. (On my local docker image, it takes 4.8 seconds to compile the [p2-cv](https://github.com/eecs280staff/p2-cv) matrix tests without the `<regex>` header, but 19.3 seconds with the header.) To avoid this, this PR disable regular expressions by default. The user can enable them by defining `UNIT_TEST_ENABLE_REGEXP` to 1 prior to #including the framework.