### PR TITLE
More Tutorial Adjustments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,7 +234,9 @@ On the other hand, when run against a correct implementation, all of your tests 
 we call it _valid_.
 
 Once you feel your tests are thorough, submit `tutorial_tests.cpp` to the unit test framework tutorial
-[autograder](https://autograder.io/). It will check your tests against a set of buggy implementations
+[autograder](https://autograder.io/). (If you copied in the other tests for the `add()` function, make sure to remove them before submitting.)
+
+The autograder will check your tests against a set of buggy implementations
 of `slideRight` and `flip`, similar to the buggy versions functions provided with
 this tutorial. To earn points, your tests must detect
 (i.e. fail when run against) each of the bugs. Note that the autograder will

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,7 @@ In this tutorial, you will learn how to write test cases using a lightweight fra
 - [Setting Up](#setting-up)
 - [Special Test Assertions](#special-test-assertions)
 - [Example: Tests for an `add()` function](#example-tests-for-an-add-function)
-- [Writing Unit Tests for `slideright()` and `flip() vector functions`](#writing-unit-tests-for-slideright-and-flip-vector-functions)
-- [Writing Helper Functions for Tests](#writing-helper-functions-for-tests)
+- [Writing Unit Tests for `slideright()` and `flip()` vector functions](#writing-unit-tests-for-slideright-and-flip-vector-functions)
 
 <!-- tocstop -->
 

--- a/tutorial_buggy_impls.cpp
+++ b/tutorial_buggy_impls.cpp
@@ -116,8 +116,9 @@ void flip(std::vector<int> &v) {
 #elif defined FLIP_BUG_3
 // Bug Description: Allows left and right indices to cross over each other.
 // Indices will go outside the vectors and eventually crash. Only manifests
-// for even length vectors.
+// for even length (non-empty) vectors.
 void flip(std::vector<int> &v) {
+  if (v.empty()) { return; }
   for (int front = 0, back = static_cast<int>(v.size()-1); front != back;
        ++front, --back) {
     int tmp = v.at(front);

--- a/tutorial_hints.json
+++ b/tutorial_hints.json
@@ -1,6 +1,6 @@
 {
   "SLIDE_RIGHT_BUG_1": [
-    "slideRight() Bug #1 - Make sure you've tested the slideRightcases with several different numbers in the vector."
+    "slideRight() Bug #1 - Make sure you've tested slideRight() with several different numbers in the vector."
   ],
   "SLIDE_RIGHT_BUG_2": [
     "slideRight() Bug #2 - Make sure you've tested cases where each value in the vector is different."
@@ -9,7 +9,7 @@
     "slideRight() Bug #3 - Make sure you've tested cases where the vector is empty."
   ],
   "FLIP_BUG_1": [
-    "flip() Bug #1 - Make sure you have tests for the flip() function and you are verifying results in each. This bug should manifest on almost any test case."
+    "flip() Bug #1 - Make sure you have tests for the flip() function and you are verifying results in each test. This bug should manifest on almost any test case."
   ],
   "FLIP_BUG_2": [
     "flip() Bug #2 - Make sure you have tests for some vectors with an odd number of elements."

--- a/tutorial_hints.json
+++ b/tutorial_hints.json
@@ -1,0 +1,20 @@
+{
+  "SLIDE_RIGHT_BUG_1": [
+    "slideRight() Bug #1 - Make sure you've tested the slideRightcases with several different numbers in the vector."
+  ],
+  "SLIDE_RIGHT_BUG_2": [
+    "slideRight() Bug #2 - Make sure you've tested cases where each value in the vector is different."
+  ],
+  "SLIDE_RIGHT_BUG_3": [
+    "slideRight() Bug #3 - Make sure you've tested cases where the vector is empty."
+  ],
+  "FLIP_BUG_1": [
+    "flip() Bug #1 - Make sure you have tests for the flip() function and you are verifying results in each. This bug should manifest on almost any test case."
+  ],
+  "FLIP_BUG_2": [
+    "flip() Bug #2 - Make sure you have tests for some vectors with an odd number of elements."
+  ],
+  "FLIP_BUG_3": [
+    "flip() Bug #3 - Make sure you have tests for some vectors with an even number of elements."
+  ]
+}


### PR DESCRIPTION
I decided to work through the tutorial one more time as part of making sure lab 2 was ready to go.

Here's a few more tutorial adjustments I think would help. The most significant change is making the "even length" bug for `flip()` only manifest on non-empty vectors. I think it's probably best to make it a little more challenging to get to 6/6 for the bugs. I've also written up hints for the bugs (in `tutorial_hints.json`) and asked James Perretta to add them to the AG site for the tutorial. 

F24 autograder is updated with these changes. 