### PR TITLE
Tutorial: Allow add() tests on autograder submission

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,9 +234,7 @@ On the other hand, when run against a correct implementation, all of your tests 
 we call it _valid_.
 
 Once you feel your tests are thorough, submit `tutorial_tests.cpp` to the unit test framework tutorial
-[autograder](https://autograder.io/). (If you copied in the other tests for the `add()` function, make sure to remove them before submitting.)
-
-The autograder will check your tests against a set of buggy implementations
+[autograder](https://autograder.io/). The autograder will check your tests against a set of buggy implementations
 of `slideRight` and `flip`, similar to the buggy versions functions provided with
 this tutorial. To earn points, your tests must detect
 (i.e. fail when run against) each of the bugs. Note that the autograder will

--- a/tutorial_buggy_impls.cpp
+++ b/tutorial_buggy_impls.cpp
@@ -26,6 +26,11 @@
 
 using namespace std;
 
+// EFFECTS: Returns the sum of first and second.
+double add(double first, double second) {
+  return first + second;
+}
+
 // MODIFIES: the elements in v
 // EFFECTS:  All elements are "shifted" right by one unit, with the
 //           last element wrapping around to the beginning.


### PR DESCRIPTION
Sorry to spam a bunch of PRs. I realized it would make much more sense for the autograder to allow tests for `add()`, which is part of the tutorial, rather than the note I previously put in the spec that students had to remove them before submitting.

This PR provides an implementation of `add()` in `tutorial_buggy_impls.cpp`. It doesn't add any buggies for that function - the idea is just that students working through the tutorial won't run into an annoying error (and staff have to answer the question in lab) if students submit without removing the `add()` tests.

I've updated the F24 autograder with the new `tutorial_buggy_impls.cpp` file.

The 10:30AM submission here originally failed, but I reran after updating the config and it now allows `add()` tests:
https://autograder.io/web/project/2668?current_tab=student_lookup&current_student_lookup=495045